### PR TITLE
feat: add nginx config for deployments behind a load balancer

### DIFF
--- a/nginx/nginx.behind-lb.conf
+++ b/nginx/nginx.behind-lb.conf
@@ -1,0 +1,78 @@
+# nginx config for deployments behind a load balancer (e.g. AWS ALB)
+#
+# The real_ip module extracts the real client IP from X-Forwarded-For,
+# skipping trusted proxy IPs. This prevents clients from spoofing their
+# IP to bypass rate limiting.
+#
+# Update set_real_ip_from to match your VPC CIDR or load balancer IP range.
+
+worker_processes auto;
+events {
+    worker_connections 4096;
+}
+
+http {
+    include mime.types;
+    default_type application/octet-stream;
+    sendfile on;
+    tcp_nopush on;
+    tcp_nodelay on;
+    keepalive_timeout 15;
+    keepalive_requests 1000;
+    types_hash_max_size 2048;
+    resolver 127.0.0.11 valid=30s;
+
+    # Trust load balancer IPs — update to match your VPC CIDR
+    set_real_ip_from 10.0.0.0/8;
+    set_real_ip_from 172.16.0.0/12;
+    set_real_ip_from 192.168.0.0/16;
+    real_ip_header X-Forwarded-For;
+    real_ip_recursive on;
+
+    server {
+        listen 8080;
+        server_name web;
+
+        set $upstream_web http://web:8080;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        location / {
+            proxy_pass $upstream_web;
+        }
+
+        location /static/node_modules/ {
+            alias /app/node_modules/;
+        }
+
+        location /static/ {
+            alias /app/web/;
+        }
+
+        location /test/ {
+            alias /app/test/;
+            try_files $uri $uri/ =404;
+        }
+    }
+
+    server {
+        listen 8081;
+        server_name api;
+
+        set $upstream_api http://api:8081;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        location / {
+            proxy_pass $upstream_api;
+        }
+
+        location /static/ {
+            alias /app/api/;
+        }
+    }
+}

--- a/nginx/nginx.behind-lb.conf
+++ b/nginx/nginx.behind-lb.conf
@@ -4,7 +4,7 @@
 # skipping trusted proxy IPs. This prevents clients from spoofing their
 # IP to bypass rate limiting.
 #
-# Update set_real_ip_from to match your VPC CIDR or load balancer IP range.
+# Trusts all RFC 1918 private IP ranges — works with any VPC/ALB setup.
 
 worker_processes auto;
 events {
@@ -22,7 +22,7 @@ http {
     types_hash_max_size 2048;
     resolver 127.0.0.11 valid=30s;
 
-    # Trust load balancer IPs — update to match your VPC CIDR
+    # Trust all private IP ranges (RFC 1918) as load balancer/proxy IPs
     set_real_ip_from 10.0.0.0/8;
     set_real_ip_from 172.16.0.0/12;
     set_real_ip_from 192.168.0.0/16;


### PR DESCRIPTION
## Summary

Adds `nginx/nginx.behind-lb.conf` — an nginx config variant for deployments behind a load balancer (e.g. AWS ALB).

Uses nginx's `real_ip` module to resolve the real client IP from `X-Forwarded-For`, preventing IP spoofing for rate limiting (see peermetrics/api#14).

## How it works

```nginx
set_real_ip_from 10.0.0.0/8;       # trust ALB/proxy IPs
real_ip_header X-Forwarded-For;     # read real IP from this header
real_ip_recursive on;               # walk chain right-to-left, skip trusted IPs
```

When a client spoofs `X-Forwarded-For: fake-ip`, the ALB appends the real IP: `fake-ip, real-ip`. nginx walks right-to-left, skips trusted proxy IPs, and sets `$remote_addr` to the real client IP. `X-Real-IP` then carries the correct value to Django.

## Which config to use

| Deployment | Config file |
|---|---|
| Direct (no load balancer) | `nginx.conf` (unchanged) |
| Behind ALB/load balancer | `nginx.behind-lb.conf` |

## DevOps

- Use `nginx.behind-lb.conf` in the production nginx sidecar image
- Update `set_real_ip_from` to match your VPC CIDR if needed (currently trusts all RFC 1918 ranges)
- Deploy together with peermetrics/api#14

## Test plan

- [ ] Verified locally: nginx `real_ip` module resolves correct client IP
- [ ] Spoofed `X-Forwarded-For` does not bypass IP resolution
- [ ] `nginx.conf` (direct) remains unchanged and backward compatible