### PR TITLE
fix: enable upstream keepalive to gunicorn api

### DIFF
--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -67,7 +67,7 @@ services:
       INIT_TOKEN_SECRET: "supersecret"
       SESSION_TOKEN_SECRET: "secret"
       WEB_DOMAIN: "localhost:8080"
-      REDIS_HOST: "redis://127.0.0.1:6379"
+      REDIS_HOST: "redis://redis:6379"
       DATABASE_HOST: "postgres"
       DATABASE_PORT: "5432"
       DATABASE_USER: "peeruser"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -112,9 +112,18 @@ services:
       # if we should delete all the unneeded stats events after the conference ends
       POST_CONFERENCE_CLEANUP: "True"
 
-      # 
+      #
+      # GeoIP / Map
+      #
+      # Enable to show participant locations on the dashboard map
+      # Requires an ipstack API key (get one at https://ipstack.com/signup)
+      # USE_EXTERNAL_GEOIP_PROVIDER: "True"
+      # IPSTACK_URL: "http://api.ipstack.com"
+      # IPSTACK_ACCESS_KEY: "your-ipstack-access-key"
+
+      #
       # App engine
-      # 
+      #
       # If the app is deployed on app engine
 
       # 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -97,7 +97,7 @@ services:
       # Redis config
       # 
       # Location of redis server
-      REDIS_HOST: "redis://127.0.0.1:6379"
+      REDIS_HOST: "redis://redis:6379"
 
       # 
       # DB config
@@ -112,18 +112,9 @@ services:
       # if we should delete all the unneeded stats events after the conference ends
       POST_CONFERENCE_CLEANUP: "True"
 
-      #
-      # GeoIP / Map
-      #
-      # Enable to show participant locations on the dashboard map
-      # Requires an ipstack API key (get one at https://ipstack.com/signup)
-      # USE_EXTERNAL_GEOIP_PROVIDER: "True"
-      # IPSTACK_URL: "http://api.ipstack.com"
-      # IPSTACK_ACCESS_KEY: "your-ipstack-access-key"
-
-      #
+      # 
       # App engine
-      #
+      # 
       # If the app is deployed on app engine
 
       # 

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -16,6 +16,13 @@ http {
     types_hash_max_size 2048;
     resolver 127.0.0.11 valid=30s;
 
+    upstream api_backend {
+        server api:8081;
+        keepalive 32;
+        keepalive_timeout 60s;
+        keepalive_requests 1000;
+    }
+
     server {
         listen 8080;
         server_name web;
@@ -48,14 +55,15 @@ http {
         listen 8081;
         server_name api;
 
-        set $upstream_api http://api:8081;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
 
         location / {
-            proxy_pass $upstream_api;
+            proxy_http_version 1.1;
+            proxy_set_header Connection "";
+            proxy_pass http://api_backend;
         }
 
         location /static/ {


### PR DESCRIPTION
Nginx was proxying to the api upstream over HTTP/1.0, which forces Connection: close on every request. On high-frequency endpoints like POST /v1/stats this meant a full TCP handshake + gunicorn connection setup per event, plus a "Closing connection." entry in the api log after every request.

- Add an api_backend upstream block with keepalive pool (32 idle sockets, 60s idle timeout, 1000 requests per socket).
- Switch the api location to proxy_http_version 1.1 and clear the Connection header so nginx can reuse upstream sockets.
- Scope these directives to the api location only; web is left on its existing variable-based proxy_pass to avoid changing behavior there.
- Point REDIS_HOST at the redis service name in both compose files so containers resolve it via the docker network rather than 127.0.0.1.
- Minor comment cleanup in docker-compose.yaml.

The matching gunicorn keepalive bump (so the api doesn't close pooled sockets after 2s) ships separately in the peermetrics/api repo.

Made-with: Cursor